### PR TITLE
Update build-scripts to include Python 3.5.

### DIFF
--- a/build-scripts/README
+++ b/build-scripts/README
@@ -1,7 +1,7 @@
 ### Building wheels
 
 This directory contains a utility script (`build.sh`) which can be used to 
-create completely self-contained manylinux wheels for Python 3.6 - 3.8. The 
+create completely self-contained manylinux wheels for Python 3.5 - 3.8. The
 build script fetches the latest release of Sqlite and generates the source
 amalgamation and header file, which are then compiled into `pysqlite3`. The
 resulting Python package can be deployed to any linux environment and will

--- a/build-scripts/_build_wheels.sh
+++ b/build-scripts/_build_wheels.sh
@@ -6,6 +6,9 @@ cd /io/pysqlite3
 
 sed -i "s|name='pysqlite3-binary'|name=PACKAGE_NAME|g" setup.py
 
+PY35="/opt/python/cp35-cp35m/bin"
+"${PY35}/python" setup.py build_static
+
 PY36="/opt/python/cp36-cp36m/bin"
 "${PY36}/python" setup.py build_static
 
@@ -17,6 +20,7 @@ PY38="/opt/python/cp38-cp38/bin"
 
 sed -i "s|name=PACKAGE_NAME|name='pysqlite3-binary'|g" setup.py
 
+"${PY35}/pip" wheel /io/pysqlite3 -w /io/wheelhouse
 "${PY36}/pip" wheel /io/pysqlite3 -w /io/wheelhouse
 "${PY37}/pip" wheel /io/pysqlite3 -w /io/wheelhouse
 "${PY38}/pip" wheel /io/pysqlite3 -w /io/wheelhouse

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools import Extension
 # If you need to change anything, it should be enough to change setup.cfg.
 
 PACKAGE_NAME = 'pysqlite3'
-VERSION = '0.4.2'
+VERSION = '0.4.3'
 
 # define sqlite sources
 sources = [os.path.join('src', source)


### PR DESCRIPTION
3.5 is the default Python3 on Ubuntu 18.04, which has comes with SQLite 3.11.0 from early 2016.

Being able to `pip install pysqlite3-binary` would be brilliant.