### PR TITLE
Increase the host parameter limit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,9 @@ class AmalgationLibSqliteBuilder(build_ext):
         # Always use memory for temp store.
         ext.define_macros.append(("SQLITE_TEMP_STORE", "3"))
 
+        # Increase the maximum number of "host parameters" which SQLite will accept
+        ext.define_macros.append(("SQLITE_MAX_VARIABLE_NUMBER", "250000"))
+
         ext.include_dirs.append(self.amalgamation_root)
         ext.sources.append(os.path.join(self.amalgamation_root, "sqlite3.c"))
 


### PR DESCRIPTION
This increases the maximum number of placeholders SQLite will accept.
See: https://www.sqlite.org/limits.html#max_variable_number

By default it is set at 999, presumably because the default
configuration needs to work with highly memory-constrained embedded
devices. Most OS distributions of SQLite increase this number
significantly. For example, on Ubuntu it is 250,000 and on OS X it is
500,000. See:
https://launchpad.net/ubuntu/+source/sqlite3/3.8.0.2-1ubuntu1
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=717900