### PR TITLE
Increase maximum mmap size

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,9 @@ class AmalgationLibSqliteBuilder(build_ext):
         # Increase the maximum number of "host parameters" which SQLite will accept
         ext.define_macros.append(("SQLITE_MAX_VARIABLE_NUMBER", "250000"))
 
+        # Increase maximum allowed memory-map size to 1TB
+        ext.define_macros.append(("SQLITE_MAX_MMAP_SIZE", str(2**40)))
+
         ext.include_dirs.append(self.amalgamation_root)
         ext.sources.append(os.path.join(self.amalgamation_root, "sqlite3.c"))
 


### PR DESCRIPTION
This increases the maximum size of database file which can be
memory-mapped from 2GB to 1TB. Note that this only changes the *maximum*
and the *default* remains at 0 (i.e. memory-mapping disabled) so this
shouldn't make any difference to users unless they explicitly ask to
mmap more than 2GB of data.

I'm not sure why the default is so low to be honest. Here are a few
threads discussing the benefits of increasing it:
http://sqlite.1065341.n5.nabble.com/SQLITE-MAX-MMAP-SIZE-2GB-default-td106789.html
https://github.com/xerial/sqlite-jdbc/issues/327
https://github.com/xerial/sqlite-jdbc/pull/328