### PR TITLE
Use manylinux2014 docker image

### DIFF
--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -24,7 +24,7 @@ cp "sqlite/sqlite3.c" pysqlite3/
 cp "sqlite/sqlite3.h" pysqlite3/
 
 # Create the wheels and strip symbols to produce manylinux wheels.
-docker run -it -v $(pwd):/io quay.io/pypa/manylinux_2_24_x86_64 /io/_build_wheels.sh
+docker run -it -v $(pwd):/io quay.io/pypa/manylinux2014_x86_64 /io/_build_wheels.sh
 
 # Remove un-stripped wheels.
 sudo rm ./wheelhouse/*-linux_*


### PR DESCRIPTION
Hey there, following up on https://github.com/coleifer/pysqlite3/issues/40#issuecomment-1523882073

I went through your code, and I realized the structure was super intuitive :+1:
And before I knew it I was able to get the project working on manyinux_2_17 quite easily :)

So, decided to create a PR to use the manylinux2014 (aka manylinux_2_17) docker from pypa.

I tested this locally, and:
```
$ bash build.sh
... no errors ...

$ ls wheelhouse/
...
pysqlite3_binary-0.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
```

If this seems good, would be great to get this merged !