### PR TITLE
Call sqlite3_initialize() during module initialization.

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -567,7 +567,7 @@ PyMODINIT_FUNC PyInit__sqlite3(void)
     converters_init(dict);
 
 error:
-    if (PyErr_Occurred())
+    if (PyErr_Occurred() || sqlite3_initialize() != SQLITE_OK)
     {
         PyErr_SetString(PyExc_ImportError, MODULE_NAME ": init failed");
         Py_XDECREF(module);


### PR DESCRIPTION
This allows pysqlite3 to pass all tests when custom-built with recommended compile-time option `SQLITE_OMIT_AUTOINIT` at https://www.sqlite.org/compile.html.

Passed ci-tests at https://github.com/kaizhu256/pysqlite3/actions.