### PR TITLE
Implement the beginnings of a new C-API Capsule

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 sources = [os.path.join('src', source)
            for source in ["module.c", "connection.c", "cursor.c", "cache.c",
                           "microprotocols.c", "prepare_protocol.c",
-                          "statement.c", "util.c", "row.c", "blob.c"]]
+                          "statement.c", "util.c", "row.c", "blob.c", "capi.c"]]
 include_dirs = []
 libraries = []
 

--- a/src/capi.c
+++ b/src/capi.c
@@ -1,0 +1,2 @@
+#include "capi.h"
+/* TODO: Funcitons Soon as I'm able to figure out what to add */

--- a/src/capi.h
+++ b/src/capi.h
@@ -1,0 +1,71 @@
+#ifndef __CAPI_H__
+#define __CAPI_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* This is not apart of the original PySqlite Source code but 
+was added in to allow others to extend and speedup 
+it's functionality elsewhere, examples: C, Rust (pyo3), Cython */
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <sqlite3.h>
+#include "blob.h"
+#include "cache.h"
+#include "connection.h"
+#include "cursor.h"
+#include "microprotocols.h"
+#include "module.h"
+#include "prepare_protocol.h"
+#include "row.h"
+#include "statement.h"
+#include "util.h"
+
+
+
+#define PYSQLITE_MODULE_NAME "pysqlite3._sqlite3"
+#define PYSQLITE_CAPI_NAME "CAPI"
+#define PYSQLITE_CAPSULE_NAME PYSQLITE_MODULE_NAME "." PYSQLITE_CAPI_NAME
+
+typedef struct _pysqlite_capi {
+    /* Types */
+    PyTypeObject* BlobType;
+    PyTypeObject* CacheType;
+    PyTypeObject* ConnectionType;
+    PyTypeObject* CursorType;
+    PyTypeObject* PrepareProtocolType;
+    PyTypeObject* RowType;
+    PyTypeObject* StatementType;
+
+    /* Exceptions */
+    PyObject* Error;
+    PyObject* Warning;
+    PyObject* InterfaceError;
+    PyObject* DatabaseError;
+    PyObject* InternalError;
+    PyObject* OperationalError;
+    PyObject* ProgrammingError;
+    PyObject* IntegrityError;
+    PyObject* DataError;
+    PyObject* NotSupportedError;
+
+
+
+
+} PySqlite_CAPI;
+
+static inline PySqlite_CAPI*
+PySqlite_Import()
+{
+    return (PySqlite_CAPI*)PyCapsule_Import(PYSQLITE_CAPSULE_NAME, 0);
+}
+
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif // __CAPI_H__


### PR DESCRIPTION
@coleifer 
I saw this project as a very useful resource in something that I have been dying to implement. As of recently I have began to work on a new project that plans to bind [msgspec](https://github.com/jcrist/msgspec) in order to start implementing an ORM for these object types. The problem has been due to it's rather strict nature I have been unable to get it to bind to anything such as peewee3 or sqlalchemy so I'm hoping that by adding something to this fork of the old sqlite python module and in return maintaining it, that I can begin to implement what I need to get this datatype to finally have it's own base table type with some optimized functionality using this library to help me. 

I wanted to make sure you were ok with me adding in these features in first as I have seen your work in peewee3 and I think this might benefit the possibility making some real cython bindings for it and to possibly reduce the amount of header files that are needed with that project.